### PR TITLE
IE issues with .trim()

### DIFF
--- a/src/jquery-Mustache.js
+++ b/src/jquery-Mustache.js
@@ -151,7 +151,7 @@
 			$.get(url)
 				.done(function (templates) {
 					$(templates).filter('script').each(function (i, el) {
-						add(el.id, $(el).html().trim());
+						add(el.id, $.trim($(el).html()));
 					});
 
 					if ($.isFunction(onComplete)) {


### PR DESCRIPTION
I was having issues in IE with .trim()

As far as I can tell, you can use .html().trim()

So I swapped it for jQuery's $.trim()
