### PR TITLE
Support for Hogan.js

### DIFF
--- a/jquery.mustache.js
+++ b/jquery.mustache.js
@@ -160,6 +160,12 @@
 			return key;
 		});
 	}
+	
+	// Returns the template map. 
+	// Useful to use the templates with Hogan.JS and similar libraries.
+	function getTemplate(templateName) {
+	  return templateMap[templateName];
+	}	
 
 	// Expose the public methods on jQuery.Mustache
 	$.Mustache = {
@@ -171,8 +177,9 @@
 		clear: clear,
 		render: render,
 		templates: templates,
+		getTemplate: getTemplate,
 		instance: instance
-	};
+	};	
 
 	/**
 	 * Renders one or more viewModels into the current jQuery element.


### PR DESCRIPTION
Added "getTemplate" to use this cool jQuery extension with Hogan.JS.

Example:

```
  $.Mustache.load('./templates.htm').done(function() {
    var template = $.Mustache.getTemplate('plaintext');
    var compiledTemplate = Hogan.compile(template);
    var renderedTemplate = compiledTemplate.render();

    console.log(renderedTemplate);
  });
```
