### PR TITLE
Work with all possible IDs

### DIFF
--- a/jquery.mustache.js
+++ b/jquery.mustache.js
@@ -82,7 +82,7 @@
 		}
 
 		$.each(templateElementIds, function() {
-			var templateHtml = $('#' + this).html();
+			var templateHtml = $(document.getElementById(this)).html();
 			if (templateHtml === null) {
 				$.error('No such elementId: #' + this);
 			}

--- a/src/jquery.mustache.js
+++ b/src/jquery.mustache.js
@@ -78,7 +78,7 @@
 		}
 
 		$.each(templateElementIds, function() {
-			var templateHtml = $('#' + this).html();
+			var templateHtml = $(document.getElementById(this)).html();
 			if (templateHtml === null) {
 				$.error('No such elementId: #' + this);
 			}


### PR DESCRIPTION
Not just the ones that can incidentally be parsed by jQuery's selector parser without escaping.

It's very surprising to get errors or experience failure when using a perfectly valid ID such as "foo/bar.baz" just because jQuery's selector parser gets confused by them.  Instead of building a string for jQuery to parse and then call getElementById() on, this patch switches to using getElementById() directly, allowing any valid ID to be used.
