### PR TITLE
its not done:, its success:, sorry about the double pull!

### DIFF
--- a/jquery.mustache.js
+++ b/jquery.mustache.js
@@ -140,15 +140,15 @@
 	function load(url, onComplete) {
 		return $.ajax({
 				url: url,
-				dataType: options.externalTemplateDataType
-			}).done(function (templates) {
-				$(templates).filter('script').each(function (i, el) {
-					add(el.id, $(el).html());
-				});
-
-				if ($.isFunction(onComplete)) {
-					onComplete();
-				}
+				dataType: options.externalTemplateDataType,
+		   		success:function (templates) {
+          				$(templates).filter('script').each(function (i, el) {
+            					add(el.id, $(el).html());
+        				  });
+         				 if ($.isFunction(onComplete)) {
+           					 onComplete();
+          				}
+        			}
 			});
 	}
 


### PR DESCRIPTION
the fix for the .done() missing is to fold the code up into the success handler, not (as i had previously requested a pull for) to add a done handler!
