### PR TITLE
Adds method to load and render a template into an element in one step

### DIFF
--- a/jquery.mustache.js
+++ b/jquery.mustache.js
@@ -211,4 +211,27 @@
 		});
 	};
 
+    /**
+     * Allows you to load a template and render it in one step, e.g.
+     *      $("#Placeholder").load("template-url.html", viewData);
+     *
+     * @param url
+     * @param templateData
+     * @param settings      optional, default to method: 'html', i.e. using jQuery's .html() to render the template
+     * @param templateName  optional, defaults to the first template in the file
+     * @param onComplete    optional
+     */
+    $.fn.load = function (url, templateData, settings, templateName, onComplete) {
+        var self = this;
+        settings = $.extend({
+            method: 'html'
+        }, settings);
+
+        templateName = templateName === null ? $.Mustache.templates()[0] : templateName;
+
+        $.Mustache.load(url, onComplete)
+            .done(function () {
+                self.mustache(templateName, templateData, settings);
+            });
+    };
 }(jQuery, window));

--- a/test/tests.js
+++ b/test/tests.js
@@ -179,7 +179,7 @@ QUnit.test("load() returns a Promise object", function () {
 	QUnit.equal(typeof $.Mustache.load("template_url").done, "function", "$.Mustache.load returns a Promise object");
 });
 
-QUnit.test("load() parses response and adds templtes contained in script blocks", function () {
+QUnit.test("load() parses response and adds templates contained in script blocks", function () {
 	var promise = $.Deferred();
 	var mockTemplates = $("<script id='template_a' /><script id='template_b' />");
 
@@ -251,4 +251,14 @@ QUnit.test("has() can be used to query the presence of registered templates", fu
 
 	QUnit.equal($.Mustache.has("non_existent"), false);
 	QUnit.equal($.Mustache.has("added_template"), true);
+});
+
+QUnit.test("$.fn.load() calls $.Mustache.load", function() {
+    var spy = this.spy($.Mustache, 'load');
+    var templateUrl = 'template-url';
+
+    $.fn.load(templateUrl, {});
+
+    QUnit.ok(spy.calledOnce);
+    QUnit.ok(spy.calledWith(templateUrl));
 });


### PR DESCRIPTION
I prefer to have one template per file.  In this case, it's annoying to have to load the template first, and then render it.  This method allows you to do both in one step, i.e.:

```
$("#template-placeholder").load("template.html", viewData); 
```

The default method is .html() because I think in cases where you would use .append(), you'd probably be rendering the same template multiple times in which case this new .load() method isn't as useful.  I realise this could be confusing for users so am happy to change it back to .append() if you prefer!

I'd like to add a demo / example for this as well, but the demo pages use src/jquery.mustache.js and I'm not sure if I should be editing that as well. 
