### PR TITLE
Added support for partials object

### DIFF
--- a/jquery.mustache.js
+++ b/jquery.mustache.js
@@ -120,7 +120,7 @@
 	function getPartialsObject(partials) {
 		var partialsObject = $.extend({}, templateMap);
 		
-	    if (partials !== void 0) {
+		if (partials !== void 0) {
 			$.each(partials, function(partialName, templateName) {
 				if (has(templateName)) {
 					partialsObject[partialName] = templateMap[templateName];
@@ -133,7 +133,7 @@
 				}
 			});
 		}
-		
+
 		return partialsObject;
 	}
 

--- a/jquery.mustache.js
+++ b/jquery.mustache.js
@@ -112,19 +112,44 @@
 		templateMap = {};
 		getMustache().clearCache();
 	}
+	
+	/**
+	 * Gets partials object (i.e. map {partial name -> actual template content})
+	 * as required by Mustache.
+	 */
+	function getPartialsObject(partials) {
+		var partialsObject = $.extend({}, templateMap);
+		
+	    if (partials !== void 0) {
+			$.each(partials, function(partialName, templateName) {
+				if (has(templateName)) {
+					partialsObject[partialName] = templateMap[templateName];
+				}
+				else {
+					if (options.warnOnMissingTemplates) {
+						$.error('No template registered for: ' + templateName);
+					}
+					partialsObject[partialName] = '';
+				}
+			});
+		}
+		
+		return partialsObject;
+	}
 
 	/**
 	 * Renders a previously added Mustache template using the supplied templateData object.  Note if the supplied
 	 * templateName doesn't exist an empty String will be returned.
 	 */
-	function render(templateName, templateData) {
+	function render(templateName, templateData, partials) {
 		if (!has(templateName)) {
 			if (options.warnOnMissingTemplates) {
 				$.error('No template registered for: ' + templateName);
 			}
 			return '';
 		}
-		return getMustache().to_html(templateMap[templateName], templateData, templateMap);
+
+		return getMustache().to_html(templateMap[templateName], templateData, getPartialsObject(partials));
 	}
 
 	/**
@@ -184,14 +209,15 @@
 	 * @param templateData	One or more JavaScript objects which will be used to render the Mustache
 	 *						template.
 	 * @param options.method	jQuery method to use when rendering, defaults to 'append'.
+	 * @param partials      Optional dynamic partials map which will be used to render the template.
 	 */
-	$.fn.mustache = function (templateName, templateData, options) {
+	$.fn.mustache = function (templateName, templateData, options, partials) {
 		var settings = $.extend({
 			method:	'append'
 		}, options);
 
 		var renderTemplate = function (obj, viewModel) {
-			$(obj)[settings.method](render(templateName, viewModel));
+			$(obj)[settings.method](render(templateName, viewModel, partials));
 		};
 
 		return this.each(function () {


### PR DESCRIPTION
jQuery Mustache plugin was missing support for partial objects which are supported by Mustache. From Mustache docs:

> In mustache.js an object of partials may be passed as the third argument to `Mustache.render`. The object should be keyed by the name of the partial, and its value should be the partial text.
> 
> ``` js
> Mustache.render(template, view, {
>   user: userTemplate
> });
> ```

The patch adds support for such object. This allows to choose partial templates dynamically. For example, if template has partial with name `{{> content}}`, it is now possible to render some differently named template in place of this partial.

Here's an usage example:

``` html
        <script type="text/html" id="div">
            <div>
            Div content:
            {{> content}}
            </div>
        </script>
        <script type="text/html" id="content1">
            Hello world!
        </script>
        <script type="text/html" id="content2">
            Bye world!
        </script>
```

``` js
    $('body').mustache('div', {}, {}, {content: 'content1'});
    $('body').mustache('div', {}, {}, {content: 'content2'});
```

And the result:

```
Div content: Hello world!
Div content: Bye world!
```
